### PR TITLE
fix(sec): upgrade commons-io:commons-io to 2.7

### DIFF
--- a/ForestBlog/pom.xml
+++ b/ForestBlog/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.liuyanzhao</groupId>
     <artifactId>ForestBlog</artifactId>
@@ -170,7 +170,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.7</version>
         </dependency>
 
         <!-- jackson -->


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in commons-io:commons-io 2.4
- [CVE-2021-29425](https://www.oscs1024.com/hd/CVE-2021-29425)


### What did I do？
Upgrade commons-io:commons-io from 2.4 to 2.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS