### PR TITLE
fix(sec): upgrade org.mybatis:mybatis to 3.5.6

### DIFF
--- a/ForestBlog/pom.xml
+++ b/ForestBlog/pom.xml
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>org.mybatis</groupId>
             <artifactId>mybatis</artifactId>
-            <version>3.4.0</version>
+            <version>3.5.6</version>
         </dependency>
         <dependency>
             <groupId>org.mybatis</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.mybatis:mybatis 3.4.0
- [CVE-2020-26945](https://www.oscs1024.com/hd/CVE-2020-26945)


### What did I do？
Upgrade org.mybatis:mybatis from 3.4.0 to 3.5.6 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS